### PR TITLE
initial commit of the tracer impl

### DIFF
--- a/tracer/default_handler.go
+++ b/tracer/default_handler.go
@@ -1,0 +1,21 @@
+package tracer
+
+import (
+	"gopkg.in/go-playground/stats.v1"
+)
+
+func InitializeMyOwnServerForHandler() {
+	server := NewTracerServer(TracerParams{
+		Domain: "localhost",
+	})
+	server.SetHandler(TracerStatsHandler{
+		func(stats *stats.Stats) {
+			// handle any incoming stats
+		},
+	})
+	server.Start()
+}
+
+func (h *MyCustomHandler) HandleStats(stats *stats.Stats) {
+	h.Handler(stats)
+}

--- a/tracer/default_handler.go
+++ b/tracer/default_handler.go
@@ -15,7 +15,3 @@ func InitializeMyOwnServerForHandler() {
 	})
 	server.Start()
 }
-
-func (h *MyCustomHandler) HandleStats(stats *stats.Stats) {
-	h.Handler(stats)
-}

--- a/tracer/go.mod
+++ b/tracer/go.mod
@@ -1,0 +1,13 @@
+module github.com/application-research/estuary-metrics/tracer
+
+go 1.18
+
+require (
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
+	github.com/tklauser/go-sysconf v0.3.11 // indirect
+	github.com/tklauser/numcpus v0.6.0 // indirect
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+	gopkg.in/go-playground/stats.v1 v1.0.2 // indirect
+)

--- a/tracer/go.sum
+++ b/tracer/go.sum
@@ -1,0 +1,15 @@
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
+github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
+github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
+github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
+github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
+github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
+github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/go-playground/stats.v1 v1.0.2 h1:vhx++4L86KJv20aC9mg4Tgo+LdWm2fCqWqHVFlBi1FY=
+gopkg.in/go-playground/stats.v1 v1.0.2/go.mod h1:L7vhfqo1la+ZHXPX+xMsNzObVP+EGBJNmRDAJhHFpbs=

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -7,8 +7,13 @@ import (
 )
 
 type TracerServer struct {
-	Ctx    context.Context
-	Server *stats.ServerStats
+	Ctx     context.Context
+	Server  *stats.ServerStats
+	Handler TracerStatsHandler
+}
+
+type TracerStatsHandler struct {
+	HandleStats func(stats *stats.Stats)
 }
 
 type TracerParams struct {
@@ -36,13 +41,19 @@ func NewTracerServer(tracerParams TracerParams) *TracerServer {
 		Ctx:    ctx,
 		Server: server,
 	}
+}
 
+// Setting the handler for the TracerServer.
+func (t *TracerServer) SetHandler(handler TracerStatsHandler) {
+	t.Handler = handler
 }
 
 // Start
 func (t *TracerServer) Start() {
 	for stat := range t.Server.Run() {
-
+		if t.Handler.HandleStats != nil {
+			t.Handler.HandleStats(stat) // let this handle the stats from the client
+		}
 		// calculate CPU times
 		// totalCPUTimes := stat.CalculateTotalCPUTimes()
 		// perCoreCPUTimes := stat.CalculateCPUTimes()

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1,0 +1,58 @@
+package tracer
+
+import (
+	"context"
+	"fmt"
+	"gopkg.in/go-playground/stats.v1"
+)
+
+type TracerServer struct {
+	Ctx    context.Context
+	Server *stats.ServerStats
+}
+
+type TracerParams struct {
+	Ctx    context.Context
+	Domain string
+	Port   int
+	Debug  bool
+}
+
+func NewTracerServer(tracerParams TracerParams) *TracerServer {
+	ctx := tracerParams.Ctx
+	config := &stats.ServerConfig{
+		Domain: tracerParams.Domain,
+		Port:   tracerParams.Port,
+		Debug:  tracerParams.Debug,
+	}
+
+	server, err := stats.NewServer(config)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &TracerServer{
+		Ctx:    ctx,
+		Server: server,
+	}
+
+}
+
+// Start
+func (t *TracerServer) Start() {
+	for stat := range t.Server.Run() {
+
+		// calculate CPU times
+		// totalCPUTimes := stat.CalculateTotalCPUTimes()
+		// perCoreCPUTimes := stat.CalculateCPUTimes()
+
+		// Do whatever you want with the data
+		// * Save to database
+		// * Stream elsewhere
+		// * Print to console
+		//
+
+		fmt.Println(stat)
+	}
+}

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -1,0 +1,50 @@
+package tracer
+
+import (
+	"context"
+	"gopkg.in/go-playground/stats.v1"
+	"reflect"
+	"testing"
+)
+
+func TestNewTracerServer(t *testing.T) {
+	type args struct {
+		tracerParams TracerParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *TracerServer
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewTracerServer(tt.args.tracerParams); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewTracerServer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTracerServer_Start(t1 *testing.T) {
+	type fields struct {
+		Ctx    context.Context
+		Server *stats.ServerStats
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t := &TracerServer{
+				Ctx:    tt.fields.Ctx,
+				Server: tt.fields.Server,
+			}
+			t.Start()
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Simple tracer for Estuary Metrics API. It extends the go-playground stats to push additional estuary specific metrics to a DB.
